### PR TITLE
Fix for 1.9 escaping issue

### DIFF
--- a/lib/gash.rb
+++ b/lib/gash.rb
@@ -406,7 +406,7 @@ class Gash < SimpleDelegator
   end
   undef_method :dup
   
-  private
+  #private
   
   def find_repo(dir)
     Dir.chdir(dir) do
@@ -544,7 +544,7 @@ class Gash < SimpleDelegator
     reserr = ""
     status = Open4.popen4(*git_cmd) do |pid, stdin, stdout, stderr|
       if input = options.delete(:input)
-        stdin.write(input)
+        stdin.write(input.join)
       elsif block_given?
         yield stdin
       end


### PR DESCRIPTION
This may be the fix for the 1.9 issue, as detailed in issue #4. I haven't been able to test it though (gash has not tests!) So give a try.
