### PR TITLE
Specs and bug fixes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,5 @@
+--color
+-fs
+-Ilib
+-Ispec
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,7 @@
 source :rubygems
 gemspec
+
+group :test do
+  gem "rspec-core"
+  gem "rspec"
+end

--- a/lib/gash.rb
+++ b/lib/gash.rb
@@ -81,7 +81,7 @@ class Gash < SimpleDelegator
     # Checks if this object has been changed (since last commit).
     def changed?; !@sha1 end
     # Mark this, and all parents as changed.
-    def changed!; @sha1 = nil;parent.changed! if parent and not parent = self end
+    def changed!; @sha1 = nil;parent.changed! if parent and not parent == self end
     # Returns the Gash-object (top-parent).
     def gash; parent.gash if parent end
     

--- a/spec/gash_spec.rb
+++ b/spec/gash_spec.rb
@@ -1,0 +1,5 @@
+describe Gash do
+  it "should not crash" do
+    true.should be_true
+  end
+end

--- a/spec/gash_spec.rb
+++ b/spec/gash_spec.rb
@@ -15,4 +15,13 @@ describe Gash do
     hash = gash.commit("My commit message")
     list_files(hash).should include("File")
   end
+
+  it "can override files" do
+    gash["File"] = "data"
+    hash = gash.commit("My commit message")
+    list_files(hash).should include("File")
+    gash["File"] = "other"
+    hash = gash.commit("My commit message 2")
+    content_for("File").should match(/other/)
+  end
 end

--- a/spec/gash_spec.rb
+++ b/spec/gash_spec.rb
@@ -9,4 +9,10 @@ describe Gash do
     gash["File"] = "data"
     gash.should_not be_empty
   end
+
+  it "commits files when #commit are applied to gash object" do
+    gash["File"] = "data"
+    hash = gash.commit("My commit message")
+    list_files(hash).should include("File")
+  end
 end

--- a/spec/gash_spec.rb
+++ b/spec/gash_spec.rb
@@ -1,5 +1,7 @@
 describe Gash do
-  it "should not crash" do
-    true.should be_true
+  let(:gash) { Gash.new(path) }
+
+  it "starts with an empty directory" do
+    gash.should be_empty
   end
 end

--- a/spec/gash_spec.rb
+++ b/spec/gash_spec.rb
@@ -22,6 +22,14 @@ describe Gash do
     list_files(hash).should include("File")
     gash["File"] = "other"
     hash = gash.commit("My commit message 2")
-    content_for("File").should match(/other/)
+    content.should match(/other/)
+  end
+
+  it "can create a tree" do
+    gash["my-folder/file"] = "content"
+    hash = gash.commit("My commit message")
+    content.should match(/content/)
+    folder("my-folder").should_not be_nil
+    folder("non-existing").should be_nil
   end
 end

--- a/spec/gash_spec.rb
+++ b/spec/gash_spec.rb
@@ -4,4 +4,9 @@ describe Gash do
   it "starts with an empty directory" do
     gash.should be_empty
   end
+
+  it "should not be empty after a file has been added" do
+    gash["File"] = "data"
+    gash.should_not be_empty
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+require "rspec"
+require "gash"
+require "./spec/support/helper"
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+  config.include Helper
+  config.before(:each) { setup }
+  config.after(:each) { teardown }
+end

--- a/spec/support/helper.rb
+++ b/spec/support/helper.rb
@@ -38,4 +38,11 @@ module Helper
       row.match(/#{dir}/) and row.match(/tree/)
     end.first
   end
+
+  #
+  # @return String The last commit message
+  #
+  def last_commit_message
+    `cd #{path} && git log --pretty='format:%s' -n 1`
+  end
 end

--- a/spec/support/helper.rb
+++ b/spec/support/helper.rb
@@ -11,4 +11,12 @@ module Helper
   def teardown
     `rm -rf #{path}`
   end
+
+  #
+  # @hash String A commit hash
+  # @return Array<String> A list of files
+  #
+  def list_files(hash)
+    `cd #{path} && git show --pretty='format:' --name-only #{hash}`.strip.split("\n")
+  end
 end

--- a/spec/support/helper.rb
+++ b/spec/support/helper.rb
@@ -1,11 +1,11 @@
-require "digest/sha1"
+require "tmpdir"
 module Helper
   def path
-    @@path ||= "/tmp/#{Digest::SHA1.hexdigest(Time.now.to_s)}"
+    @path ||= Dir.mktmpdir
   end
 
   def setup
-    `mkdir #{path} && cd #{path} && git init`
+    `cd #{path} && git init`
   end
 
   def teardown

--- a/spec/support/helper.rb
+++ b/spec/support/helper.rb
@@ -26,4 +26,16 @@ module Helper
   def content
     `cd #{path} && git show HEAD`
   end
+
+  #
+  # @dir String Folder to retrive
+  # @return String 
+  #   Example: 040000 tree d91d06157bdc633d25f970b9cc54d0eb74fb850f my-folder
+  #
+  def folder(dir)
+    tree = `cd #{path} && git cat-file -p HEAD`.split(" ")[1]
+    `cd #{path} && git cat-file -p #{tree}`.split("\n").select do |row| 
+      row.match(/#{dir}/) and row.match(/tree/)
+    end.first
+  end
 end

--- a/spec/support/helper.rb
+++ b/spec/support/helper.rb
@@ -1,0 +1,14 @@
+require "digest/sha1"
+module Helper
+  def path
+    @@path ||= "/tmp/#{Digest::SHA1.hexdigest(Time.now.to_s)}.git"
+  end
+
+  def setup
+    `mkdir #{path} && cd #{path} && git init`
+  end
+
+  def teardown
+    `rm -rf #{path}`
+  end
+end

--- a/spec/support/helper.rb
+++ b/spec/support/helper.rb
@@ -1,7 +1,7 @@
 require "digest/sha1"
 module Helper
   def path
-    @@path ||= "/tmp/#{Digest::SHA1.hexdigest(Time.now.to_s)}.git"
+    @@path ||= "/tmp/#{Digest::SHA1.hexdigest(Time.now.to_s)}"
   end
 
   def setup

--- a/spec/support/helper.rb
+++ b/spec/support/helper.rb
@@ -19,4 +19,11 @@ module Helper
   def list_files(hash)
     `cd #{path} && git show --pretty='format:' --name-only #{hash}`.strip.split("\n")
   end
+
+  #
+  # @return String Diff content for last commit
+  #
+  def content
+    `cd #{path} && git show HEAD`
+  end
 end


### PR DESCRIPTION
- Using RSpec for testing
- Using `Dir.mktmpdir` instead of UNIXs `mkdir` for creating temp dirs
- [Fixed minor error](https://github.com/water/gash/commit/6c2232dd336c114d040c2e71025ef61e56ad0b68) from last (#8) pull request.
