### PR TITLE
Failing blob

### DIFF
--- a/lib/gash.rb
+++ b/lib/gash.rb
@@ -342,6 +342,10 @@ class Gash < SimpleDelegator
       @content ||= @sha1 ? load! : ''
     end
     alias_method :to_s, :__getobj__
+
+    def __setobj__(value) #:nodoc:
+      Blob.new(:content => value.to_s)
+    end
   end
   
   attr_accessor :branch, :repository

--- a/spec/gash_spec.rb
+++ b/spec/gash_spec.rb
@@ -29,8 +29,7 @@ describe Gash do
     gash["my-folder/file"] = "content"
     hash = gash.commit("My commit message")
     content.should match(/content/)
-    folder("my-folder").should_not be_nil
-    folder("non-existing").should be_nil
+    raw_commit.should match(%r{A\s+my-folder/file})
   end
 
   it "should be possible to pass a blob to path" do

--- a/spec/gash_spec.rb
+++ b/spec/gash_spec.rb
@@ -32,4 +32,12 @@ describe Gash do
     folder("my-folder").should_not be_nil
     folder("non-existing").should be_nil
   end
+
+  it "should be possible to pass a blob to path" do
+    gash["file1"] = "content"
+    gash["file2/a"] = gash["file1"]
+    gash.commit("Commit message")
+    raw_commit.should match(%r{A\s+file1})
+    raw_commit.should match(%r{A\s+file2/a})
+  end
 end

--- a/spec/support/helper.rb
+++ b/spec/support/helper.rb
@@ -45,4 +45,21 @@ module Helper
   def last_commit_message
     `cd #{path} && git log --pretty='format:%s' -n 1`
   end
+
+  #
+  # @return String
+  # @example
+  #   commit 5b580afc95c32721d35a7d659abce1e3845635a9
+  #   Author:     Linus Oleander <linus@oleander.nu>
+  #   AuthorDate: Mon Feb 27 23:16:59 2012 +0100
+  #   Commit:     Linus Oleander <linus@oleander.nu>
+  #   CommitDate: Mon Feb 27 23:16:59 2012 +0100
+  #
+  #       Add last_commit_message helper
+  #
+  #   M       spec/support/helper.rb
+  #
+  def raw_commit
+    `cd #{path} && git show --name-status --format=fuller`
+  end
 end


### PR DESCRIPTION
The following snipped failed.

``` ruby
gash["file1"] = "content"
gash["file2/a"] = gash["file1"]
gash.commit("Commit message")
```

```
Failure/Error: gash["file2/a"] = gash["file1"]
NotImplementedError:
  need to define `__setobj__'
# ./lib/gash.rb:106:in `dup'
# ./lib/gash.rb:106:in `normalize'
# ./lib/gash.rb:216:in `[]='
# ./lib/gash.rb:214:in `[]='
# ./lib/gash.rb:469:in `method_missing'
# ./spec/gash_spec.rb:38:in `block (2 levels) in <top (required)>'
```

See specs for more info.
